### PR TITLE
Fix: Correct CSS file path in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Главная страница сайта</title>
-  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <!-- Preloader -->


### PR DESCRIPTION
The 'index.html' file was referencing a non-existent 'styles.css' file, causing the website's styles not to load.

This commit corrects the path in the <link> tag to 'style.css', which is the correct filename. This resolves the issue of CSS not being applied on the GitHub Pages site.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `index.html` to reference `style.css` instead of `styles.css`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0af40aa1bbf55c56417843db4ee6921dbd9da242. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->